### PR TITLE
Fix: Correct getParentBranch functionality to properly identify parent branches

### DIFF
--- a/src/main/kotlin/com/github/hungyanbin/intellijpluginpragent/toolWindow/GitCommandHelper.kt
+++ b/src/main/kotlin/com/github/hungyanbin/intellijpluginpragent/toolWindow/GitCommandHelper.kt
@@ -32,16 +32,18 @@ class GitCommandHelper(
             // Parse the log output to find branch references
             for (line in lines) {
                 // Look for branch names in parentheses, excluding origin/ and HEAD
-                val branchMatch = Regex("\\(([^,)]+)\\)").findAll(line)
-                for (match in branchMatch) {
-                    val branchRef = match.groupValues[1]
-                    if (!branchRef.contains("HEAD") &&
-                        !branchRef.contains("origin/") &&
-                        branchRef != currentBranch.name &&
-                        branchRef.trim().isNotEmpty()) {
-                        val parentBranchName = branchRef.trim()
-                        val hash = line.split(" ")[0] // Get hash from start of line
-                        return Branch(hash = hash, name = parentBranchName)
+                val branchMatch = Regex("\\(([^)]+)\\)").find(line)
+                if (branchMatch != null) {
+                    val branchRefs = branchMatch.groupValues[1].split(",")
+                    for (branchRef in branchRefs) {
+                        val trimmedRef = branchRef.trim()
+                        if (!trimmedRef.contains("HEAD") &&
+                            !trimmedRef.startsWith("origin/") &&
+                            trimmedRef != currentBranch.name &&
+                            trimmedRef.isNotEmpty()) {
+                            val hash = line.split(" ")[0] // Get hash from start of line
+                            return Branch(hash = hash, name = trimmedRef)
+                        }
                     }
                 }
             }

--- a/src/main/kotlin/com/github/hungyanbin/intellijpluginpragent/toolWindow/GitCommandHelper.kt
+++ b/src/main/kotlin/com/github/hungyanbin/intellijpluginpragent/toolWindow/GitCommandHelper.kt
@@ -24,16 +24,6 @@ class GitCommandHelper(
         return Branch(hash = hash, name = branchName)
     }
 
-    //66aa3429be (HEAD -> feat_multipage_player_preview_14, origin/feat_multipage_player_preview_14) feat: stop the player when opening the duration picker
-    //1d4b129af3 feat: introduce PageAnimationFactory.Config to generate evaluator with different constraint
-    //366dd23d48 feat: calculate evaluatorMap if collage has pageDuration
-    //028e16fcf6 refactor: refactor PageAnimationFactory
-    //94c7ad4dad feat: add unit test for PageAnimationFactory
-    //f5b7a09978 (feat_multipage_player_preview_13) fix: MultiPagePlayer is not being recycled when activity is destroyed
-    //72c0be0eb0 feat: apply page duration to json after change from duration picker
-    //bae28f3799 feat: make collage model behaviors correct with new pageDuration property
-    //1f0ca042a4 feat: implement command for pageDuration
-    //522df001f2 feat: Add page_duration to collage structure
     private suspend fun getParentBranch(currentBranch: Branch): Branch {
         return try {
             val output = executeGitCommand(listOf("git", "log", "--oneline", "--decorate"))
@@ -105,6 +95,42 @@ class GitCommandHelper(
             executeGitCommand(listOf("git", "diff", "${fromHash}..${toHash}"))
         } catch (e: Exception) {
             ""
+        }
+    }
+
+    suspend fun getRemoteUrl(): String? {
+        return try {
+            val output = executeGitCommand(listOf("git", "remote", "get-url", "origin"))
+            output.trim().takeIf { it.isNotEmpty() }
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    suspend fun pushCurrentBranchToRemote(branchName: String): Boolean {
+        return try {
+            executeGitCommand(listOf("git", "push", "-u", "origin", branchName))
+            true
+        } catch (e: Exception) {
+            false
+        }
+    }
+
+    suspend fun checkBranchExistsOnRemote(branchName: String): Boolean {
+        return try {
+            val output = executeGitCommand(listOf("git", "ls-remote", "--heads", "origin", branchName))
+            output.trim().isNotEmpty()
+        } catch (e: Exception) {
+            false
+        }
+    }
+
+    suspend fun pushBranchToRemote(branchName: String): Boolean {
+        return try {
+            executeGitCommand(listOf("git", "push", "origin", branchName))
+            true
+        } catch (e: Exception) {
+            false
         }
     }
 }


### PR DESCRIPTION
# Fix: Correct getParentBranch functionality to properly identify parent branches

## Summary

This pull request fixes a critical bug in the `getParentBranch` method within `GitCommandHelper.kt` that was preventing the correct identification of parent branches from git log output.

## Problem Statement

The previous implementation had several issues when parsing git log output to identify parent branches:

1. **Incorrect regex matching**: Used `findAll()` which could create multiple matches and incorrect parsing logic
2. **Improper branch reference filtering**: The logic for excluding `origin/` branches used `contains()` instead of `startsWith()`, which could incorrectly filter valid local branches
3. **Inefficient parsing**: The approach didn't properly handle comma-separated branch references within parentheses

## Changes Made

### Core Fix: Improved Branch Reference Parsing
- **Regex optimization**: Changed from `findAll()` to `find()` for more precise matching of branch references in parentheses
- **Enhanced comma handling**: Properly split comma-separated branch references and process each one individually
- **Refined filtering logic**: 
  - Changed `!branchRef.contains(\