### PR TITLE
Fix: Correct Parent Branch Detection Logic

### DIFF
--- a/src/main/kotlin/com/github/hungyanbin/intellijpluginpragent/toolWindow/GitCommandHelper.kt
+++ b/src/main/kotlin/com/github/hungyanbin/intellijpluginpragent/toolWindow/GitCommandHelper.kt
@@ -32,16 +32,18 @@ class GitCommandHelper(
             // Parse the log output to find branch references
             for (line in lines) {
                 // Look for branch names in parentheses, excluding origin/ and HEAD
-                val branchMatch = Regex("\\(([^,)]+)\\)").findAll(line)
-                for (match in branchMatch) {
-                    val branchRef = match.groupValues[1]
-                    if (!branchRef.contains("HEAD") &&
-                        !branchRef.contains("origin/") &&
-                        branchRef != currentBranch.name &&
-                        branchRef.trim().isNotEmpty()) {
-                        val parentBranchName = branchRef.trim()
-                        val hash = line.split(" ")[0] // Get hash from start of line
-                        return Branch(hash = hash, name = parentBranchName)
+                val branchMatch = Regex("\\(([^)]+)\\)").find(line)
+                if (branchMatch != null) {
+                    val branchRefs = branchMatch.groupValues[1].split(",")
+                    for (branchRef in branchRefs) {
+                        val trimmedRef = branchRef.trim()
+                        if (!trimmedRef.contains("HEAD") &&
+                            !trimmedRef.startsWith("origin/") &&
+                            trimmedRef != currentBranch.name &&
+                            trimmedRef.isNotEmpty()) {
+                            val hash = line.split(" ")[0] // Get hash from start of line
+                            return Branch(hash = hash, name = trimmedRef)
+                        }
                     }
                 }
             }


### PR DESCRIPTION
# Fix: Correct Parent Branch Detection Logic

## Summary
Fixes a bug in the `getParentBranch` method where branch references containing multiple comma-separated branches were not parsed correctly. The method now properly extracts and evaluates individual branch names from git log output to identify the correct parent branch.

## Key Changes
- **Improved branch reference parsing**: Changed from `findAll()` to `find()` with proper comma-separated branch handling
- **Enhanced branch filtering**: Updated logic to use `startsWith("origin/")` instead of `contains("origin/")` for more precise remote branch exclusion
- **Fixed iteration logic**: Now correctly processes each branch reference individually rather than attempting to match multiple patterns

## Breaking Changes
None - this is a bug fix that improves existing functionality without changing the public API.