### PR TITLE
Add GitHub PR Management with Update Support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,6 +34,10 @@ repositories {
 dependencies {
     implementation(libs.kotlinxSerializationJson)
     implementation(libs.koog)
+    implementation(libs.ktorClientCore)
+    implementation(libs.ktorClientCio)
+    implementation(libs.ktorClientContentNegotiation)
+    implementation(libs.ktorSerializationJson)
     testImplementation(libs.junit)
     testImplementation(libs.opentest4j)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@
 junit = "4.13.2"
 opentest4j = "1.3.0"
 kotlinxSerialization = "1.8.0"
+ktor = "3.0.3"
 
 # plugins
 kotlinxSerializationPlugin = "2.1.20"
@@ -18,6 +19,10 @@ junit = { group = "junit", name = "junit", version.ref = "junit" }
 opentest4j = { group = "org.opentest4j", name = "opentest4j", version.ref = "opentest4j" }
 kotlinxSerializationJson = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
 koog = { group = "ai.koog", name = "koog-agents", version.ref = "koog"}
+ktorClientCore = { group = "io.ktor", name = "ktor-client-core", version.ref = "ktor" }
+ktorClientCio = { group = "io.ktor", name = "ktor-client-cio", version.ref = "ktor" }
+ktorClientContentNegotiation = { group = "io.ktor", name = "ktor-client-content-negotiation", version.ref = "ktor" }
+ktorSerializationJson = { group = "io.ktor", name = "ktor-serialization-kotlinx-json", version.ref = "ktor" }
 
 [plugins]
 changelog = { id = "org.jetbrains.changelog", version.ref = "changelog" }

--- a/src/main/kotlin/com/github/hungyanbin/intellijpluginpragent/service/GitHubAPIService.kt
+++ b/src/main/kotlin/com/github/hungyanbin/intellijpluginpragent/service/GitHubAPIService.kt
@@ -1,12 +1,18 @@
 package com.github.hungyanbin.intellijpluginpragent.service
 
+import io.ktor.client.*
+import io.ktor.client.call.*
+import io.ktor.client.engine.cio.*
+import io.ktor.client.plugins.contentnegotiation.*
+import io.ktor.client.request.*
+import io.ktor.http.*
+import io.ktor.serialization.kotlinx.json.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
-import java.net.HttpURLConnection
-import java.net.URL
 
+@Serializable
 data class CreatePRRequest(
     val title: String,
     val head: String,
@@ -29,49 +35,33 @@ data class PullRequest(
 )
 
 class GitHubAPIService {
-    private val json = Json { ignoreUnknownKeys = true }
+    private val client = HttpClient(CIO) {
+        install(ContentNegotiation) {
+            json(Json {
+                ignoreUnknownKeys = true
+                prettyPrint = true
+            })
+        }
+    }
 
     suspend fun createPullRequest(
         githubPat: String,
         repository: GitHubRepository,
         prRequest: CreatePRRequest
     ): String = withContext(Dispatchers.IO) {
-        val apiUrl = "https://api.github.com/repos/${repository.owner}/${repository.name}/pulls"
-        val connection = URL(apiUrl).openConnection() as HttpURLConnection
-
         try {
-            connection.requestMethod = "POST"
-            connection.setRequestProperty("Authorization", "token $githubPat")
-            connection.setRequestProperty("Accept", "application/vnd.github.v3+json")
-            connection.setRequestProperty("Content-Type", "application/json")
-            connection.doOutput = true
-
-            val jsonPayload = """
-                {
-                    "title": "${escapeJson(prRequest.title)}",
-                    "head": "${escapeJson(prRequest.head)}",
-                    "base": "${escapeJson(prRequest.base)}",
-                    "body": "${escapeJson(prRequest.body)}"
+            val response = client.post("https://api.github.com/repos/${repository.owner}/${repository.name}/pulls") {
+                headers {
+                    append(HttpHeaders.Authorization, "token $githubPat")
+                    append(HttpHeaders.Accept, "application/vnd.github.v3+json")
                 }
-            """.trimIndent()
-
-            connection.outputStream.use { outputStream ->
-                outputStream.write(jsonPayload.toByteArray(Charsets.UTF_8))
+                contentType(ContentType.Application.Json)
+                setBody(prRequest)
             }
 
-            val responseCode = connection.responseCode
-            val responseMessage = if (responseCode in 200..299) {
-                connection.inputStream.bufferedReader().use { it.readText() }
-            } else {
-                val errorMessage = connection.errorStream?.bufferedReader()?.use { it.readText() }
-                    ?: "HTTP $responseCode: ${connection.responseMessage}"
-                throw Exception("Failed to create PR: $errorMessage")
-            }
-
-            return@withContext responseMessage
-
-        } finally {
-            connection.disconnect()
+            return@withContext response.body<String>()
+        } catch (e: Exception) {
+            throw Exception("Failed to create PR: ${e.message}", e)
         }
     }
 
@@ -101,52 +91,52 @@ class GitHubAPIService {
         head: String,
         base: String
     ): PullRequest? = withContext(Dispatchers.IO) {
-        val apiUrl = "https://api.github.com/repos/${repository.owner}/${repository.name}/pulls?head=${repository.owner}:$head&base=$base&state=open"
-        val connection = URL(apiUrl).openConnection() as HttpURLConnection
-
         try {
-            connection.requestMethod = "GET"
-            connection.setRequestProperty("Authorization", "token $githubPat")
-            connection.setRequestProperty("Accept", "application/vnd.github.v3+json")
-
-            val responseCode = connection.responseCode
-            if (responseCode in 200..299) {
-                val responseText = connection.inputStream.bufferedReader().use { it.readText() }
-
-                // Parse JSON response manually (simple parsing for array of PRs)
-                if (responseText.trim() == "[]") {
-                    return@withContext null
+            val response = client.get("https://api.github.com/repos/${repository.owner}/${repository.name}/pulls") {
+                headers {
+                    append(HttpHeaders.Authorization, "token $githubPat")
+                    append(HttpHeaders.Accept, "application/vnd.github.v3+json")
                 }
-
-                // Extract first PR from array
-                return@withContext parseFirstPullRequest(responseText)
-            } else {
-                // If error, return null (no existing PR found or error accessing API)
-                return@withContext null
+                parameter("head", "${repository.owner}:$head")
+                parameter("base", base)
+                parameter("state", "all")
             }
 
+            val pullRequests = response.body<List<PullRequest>>()
+            return@withContext pullRequests.firstOrNull()
         } catch (e: Exception) {
             // Return null on any error
             return@withContext null
-        } finally {
-            connection.disconnect()
         }
     }
 
-    private fun parseFirstPullRequest(jsonArray: String): PullRequest? {
-        return try {
-            val pullRequests = json.decodeFromString<List<PullRequest>>(jsonArray)
-            pullRequests.firstOrNull()
+    suspend fun updatePullRequest(
+        githubPat: String,
+        repository: GitHubRepository,
+        prNumber: Int,
+        title: String,
+        body: String
+    ): String = withContext(Dispatchers.IO) {
+        try {
+            val response = client.patch("https://api.github.com/repos/${repository.owner}/${repository.name}/pulls/$prNumber") {
+                headers {
+                    append(HttpHeaders.Authorization, "token $githubPat")
+                    append(HttpHeaders.Accept, "application/vnd.github.v3+json")
+                }
+                contentType(ContentType.Application.Json)
+                setBody(mapOf(
+                    "title" to title,
+                    "body" to body
+                ))
+            }
+
+            return@withContext response.body<String>()
         } catch (e: Exception) {
-            null
+            throw Exception("Failed to update PR: ${e.message}", e)
         }
     }
 
-    private fun escapeJson(text: String): String {
-        return text.replace("\\", "\\\\")
-            .replace("\"", "\\\"")
-            .replace("\n", "\\n")
-            .replace("\r", "\\r")
-            .replace("\t", "\\t")
+    fun close() {
+        client.close()
     }
 }


### PR DESCRIPTION
# Add GitHub PR Management with Update Support

This PR enhances the GitHub integration to detect and update existing pull requests instead of creating duplicates. The implementation migrates from raw HTTP connections to Ktor client for improved reliability and adds comprehensive PR lifecycle management.

## Key Changes

- **New PR Detection**: Automatically checks for existing PRs when branch selection changes and loads their content
- **Update Functionality**: "Create PR" button becomes "Update PR" when an existing PR is detected
- **HTTP Client Migration**: Replaced `HttpURLConnection` with Ktor HTTP client for better error handling and serialization
- **Enhanced UI State**: Added button state management to disable actions for closed PRs and provide appropriate feedback
- **API Expansion**: Added `findExistingPullRequest()` and `updatePullRequest()` methods to GitHub API service

## Breaking Changes

- Added new Ktor dependencies (`ktor-client-*` libraries) - ensure version 3.0.3 compatibility with your project
- `GitHubAPIService` now requires proper cleanup via `close()` method to release HTTP client resources

The PR maintains backward compatibility for new PR creation while adding seamless update capabilities for existing ones.