### PR TITLE
Add Base Prompt Customization Feature

### DIFF
--- a/src/main/kotlin/com/github/hungyanbin/intellijpluginpragent/toolWindow/PRNotesPanelViewModel.kt
+++ b/src/main/kotlin/com/github/hungyanbin/intellijpluginpragent/toolWindow/PRNotesPanelViewModel.kt
@@ -49,6 +49,9 @@ class PRNotesPanelViewModel(private val projectBasePath: String) {
     private val _selectedCompareBranch = MutableStateFlow<String?>(null)
     val selectedCompareBranch: StateFlow<String?> = _selectedCompareBranch.asStateFlow()
 
+    private val _basePromptText = MutableStateFlow("")
+    val basePromptText: StateFlow<String> = _basePromptText.asStateFlow()
+
     private var existingPRText = ""
     private var existingPRNumber: Int? = null
     private var existingPRTitle: String? = null
@@ -141,6 +144,11 @@ class PRNotesPanelViewModel(private val projectBasePath: String) {
     init {
         loadRecentBranches()
         loadDefaultBranches()
+        loadBasePrompt()
+    }
+
+    private fun loadBasePrompt() {
+        _basePromptText.value = promptTemplateRepository.getBasePrompt()
     }
 
     private fun loadRecentBranches() {
@@ -512,6 +520,17 @@ class PRNotesPanelViewModel(private val projectBasePath: String) {
         } catch (e: Exception) {
             _statusMessage.value = "Error modifying PR notes: ${e.message}"
         }
+    }
+
+    fun onUpdateBasePromptClicked(newBasePrompt: String) {
+        if (newBasePrompt.isBlank()) {
+            _statusMessage.value = "Error: Base prompt cannot be empty"
+            return
+        }
+
+        promptTemplateRepository.updateBasePrompt(newBasePrompt)
+        _basePromptText.value = newBasePrompt
+        _statusMessage.value = "Base prompt updated successfully"
     }
 
     fun cleanup() {

--- a/src/main/kotlin/com/github/hungyanbin/intellijpluginpragent/toolWindow/PromptTemplateRepository.kt
+++ b/src/main/kotlin/com/github/hungyanbin/intellijpluginpragent/toolWindow/PromptTemplateRepository.kt
@@ -1,8 +1,15 @@
 package com.github.hungyanbin.intellijpluginpragent.toolWindow
 
 import com.github.hungyanbin.intellijpluginpragent.service.BranchHistory
+import java.io.File
 
 class PromptTemplateRepository {
+    private val storageFile = File(System.getProperty("user.home"), ".intellij-pr-agent/base-prompt.txt")
+
+    init {
+        // Ensure parent directory exists
+        storageFile.parentFile?.mkdirs()
+    }
 
     fun buildBasePrompt(branchHistory: BranchHistory, fileDiff: String): String {
         val commits = if (branchHistory.commits.isNotEmpty()) {
@@ -33,6 +40,30 @@ class PromptTemplateRepository {
     }
 
     fun getBasePrompt(): String {
+        // Try to load from disk first
+        if (storageFile.exists()) {
+            try {
+                return storageFile.readText()
+            } catch (e: Exception) {
+                // If reading fails, fall back to default
+                e.printStackTrace()
+            }
+        }
+
+        // Return default prompt if file doesn't exist or reading fails
+        return getDefaultBasePrompt()
+    }
+
+    fun updateBasePrompt(newPrompt: String) {
+        try {
+            storageFile.writeText(newPrompt)
+        } catch (e: Exception) {
+            e.printStackTrace()
+            throw e
+        }
+    }
+
+    private fun getDefaultBasePrompt(): String {
         return """
             Please create a concise pull request description that reviewers can quickly scan. Include:
 


### PR DESCRIPTION
# Add Base Prompt Customization Feature

## Summary

This PR introduces the ability for users to customize the base prompt used for generating PR descriptions. Users can now view, edit, and persist their preferred prompt template through a new dedicated tab in the PR Notes panel.

## Key Changes

- **New Base Prompt Tab**: Added a third tab to the PR Notes interface containing an editable text area for the base prompt
- **Persistent Storage**: Base prompts are now saved to disk at `~/.intellij-pr-agent/base-prompt.txt` and automatically loaded on startup
- **PromptTemplateRepository Enhancements**: 
  - Added `updateBasePrompt()` method for saving custom prompts
  - Modified `getBasePrompt()` to load from disk with fallback to default
  - Separated default prompt logic into `getDefaultBasePrompt()`
- **UI Components**: 
  - Implemented scrollable text area with word wrapping for prompt editing
  - Added "Update Base Prompt" button with validation
  - Integrated status feedback for update operations
- **ViewModel Integration**: Added state management for base prompt text with reactive UI updates

## Breaking Changes

None. The feature is purely additive and maintains backward compatibility with existing functionality.

## Impact

Users can now tailor the AI prompt to their specific project needs, team conventions, or personal preferences, leading to more consistent and relevant PR descriptions across their workflow.