### PR TITLE
Add authenticated GitHub user as assignee when creating or updating PRs

### DIFF
--- a/src/main/kotlin/com/github/hungyanbin/pragent/repository/UserRepository.kt
+++ b/src/main/kotlin/com/github/hungyanbin/pragent/repository/UserRepository.kt
@@ -1,0 +1,40 @@
+package com.github.hungyanbin.pragent.repository
+
+import com.github.hungyanbin.pragent.service.GitHubAPIService
+import com.github.hungyanbin.pragent.service.GitHubUser
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
+
+@Service
+class UserRepository {
+    private var cachedUser: GitHubUser? = null
+    private var cachedPatHash: Int? = null
+    private val githubAPIService = GitHubAPIService()
+
+    suspend fun getAuthenticatedUser(githubPat: String): GitHubUser? {
+        val currentPatHash = githubPat.hashCode()
+
+        // Return cached user if PAT hasn't changed
+        if (cachedUser != null && cachedPatHash == currentPatHash) {
+            return cachedUser
+        }
+
+        // Fetch new user and update cache
+        val user = githubAPIService.getAuthenticatedUser(githubPat)
+        if (user != null) {
+            cachedUser = user
+            cachedPatHash = currentPatHash
+        }
+
+        return user
+    }
+
+    fun clearCache() {
+        cachedUser = null
+        cachedPatHash = null
+    }
+
+    companion object {
+        fun getInstance(): UserRepository = service()
+    }
+}

--- a/src/main/kotlin/com/github/hungyanbin/pragent/startup/PRAgentStartupActivity.kt
+++ b/src/main/kotlin/com/github/hungyanbin/pragent/startup/PRAgentStartupActivity.kt
@@ -1,0 +1,30 @@
+package com.github.hungyanbin.pragent.startup
+
+import com.github.hungyanbin.pragent.repository.SecretRepository
+import com.github.hungyanbin.pragent.repository.UserRepository
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.startup.ProjectActivity
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+class PRAgentStartupActivity : ProjectActivity {
+    override suspend fun execute(project: Project) {
+        prefetchAuthenticatedUser()
+    }
+
+    private suspend fun prefetchAuthenticatedUser() = withContext(Dispatchers.IO) {
+        try {
+            val secretRepository = SecretRepository()
+            val githubPat = secretRepository.getGithubPat()
+
+            if (!githubPat.isNullOrEmpty()) {
+                val userRepository = UserRepository.getInstance()
+
+                // Pre-fetch and cache the authenticated user
+                userRepository.getAuthenticatedUser(githubPat)
+            }
+        } catch (e: Exception) {
+            // Silently fail - this is just a pre-fetch optimization
+        }
+    }
+}

--- a/src/main/kotlin/com/github/hungyanbin/pragent/toolWindow/ConfigPanel.kt
+++ b/src/main/kotlin/com/github/hungyanbin/pragent/toolWindow/ConfigPanel.kt
@@ -2,6 +2,7 @@ package com.github.hungyanbin.pragent.toolWindow
 
 import com.github.hungyanbin.pragent.domain.LLMProvider
 import com.github.hungyanbin.pragent.repository.SecretRepository
+import com.github.hungyanbin.pragent.repository.UserRepository
 import com.github.hungyanbin.pragent.service.ErrorLogger
 import com.github.hungyanbin.pragent.utils.runOnUI
 import com.intellij.ui.components.JBLabel
@@ -169,6 +170,11 @@ class ConfigPanel : JBPanel<JBPanel<*>>() {
 
             if (githubPat.isNotEmpty()) {
                 secretRepository.storeGithubPat(githubPat)
+                // Clear cached user when PAT is updated
+                val userRepository = UserRepository.getInstance()
+                userRepository.clearCache()
+                // Pre-fetch new authenticated user with the new PAT
+                userRepository.getAuthenticatedUser(githubPat)
                 messages.add("GitHub PAT saved")
             }
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -31,5 +31,6 @@
 
     <extensions defaultExtensionNs="com.intellij">
         <toolWindow factoryClass="com.github.hungyanbin.pragent.toolWindow.PRAgentWindowFactory" id="PR agent" icon="META-INF/pluginIcon.svg"/>
+        <postStartupActivity implementation="com.github.hungyanbin.pragent.startup.PRAgentStartupActivity"/>
     </extensions>
 </idea-plugin>


### PR DESCRIPTION
## Release Notes Entry
feat: add the github user as the assignee of the PR

## Technical Details
### Summary
This PR introduces functionality to automatically add the authenticated GitHub user as an assignee when creating or updating a pull request. It enhances the existing pull request creation process by associating the PR with the user who initiated it.

### Key Changes
- Added `UserRepository` to handle caching and retrieval of the authenticated GitHub user
- Modified `GitHubAPIService` to include methods for fetching the authenticated user and adding assignees to a PR
- Updated `PRNotesPanelViewModel` to add the authenticated user as an assignee after creating or updating a PR
- Introduced `PRAgentStartupActivity` to pre-fetch and cache the authenticated user on project startup for improved performance